### PR TITLE
return error if required arguments are missing from command line

### DIFF
--- a/QuiCLI.Tests/CommandLine/ParserTests.cs
+++ b/QuiCLI.Tests/CommandLine/ParserTests.cs
@@ -15,7 +15,9 @@ namespace QuiCLI.Tests.CommandLine
             var command = commandGroup.AddCommand(_ => new TestCommand()).First(c => c.Name == "test2");
             var commandLine = new string[] { "test2", "--parameter= world" };
             var parser = new CommandLineParser(commandGroup);
-            var (parsedCommand, _) = parser.Parse(commandLine);
+            var result = parser.Parse(commandLine);
+            Assert.True(result.IsSuccess);
+            var parsedCommand = result.Value.ParsedCommand;
             Assert.NotNull(parsedCommand);
             Assert.Single(parsedCommand.Arguments);
             Assert.Equal("world", parsedCommand.Arguments[0].Value);
@@ -31,7 +33,9 @@ namespace QuiCLI.Tests.CommandLine
             var command = commands.AddCommand(_ => new TestCommand()).First(c => c.Name == "test2");
             var commandLine = new string[] { "test2", "--parameter", "Foo" };
             var parser = new CommandLineParser(commands);
-            var (parsedCommand, _) = parser.Parse(commandLine);
+            var result = parser.Parse(commandLine);
+            Assert.True(result.IsSuccess);
+            var parsedCommand = result.Value.ParsedCommand;
             Assert.NotNull(parsedCommand);
             Assert.Single(parsedCommand.Arguments);
             Assert.Equal("Foo", parsedCommand.Arguments[0].Value);
@@ -51,7 +55,9 @@ namespace QuiCLI.Tests.CommandLine
             var command = commands.AddCommand(_ => new TestCommand()).First(c => c.Name == commandName);
             var commandLine = new string[] { commandName, "--parameter", value?.ToString()! };
             var parser = new CommandLineParser(commands);
-            var (parsedCommand, _) = parser.Parse(commandLine);
+            var result = parser.Parse(commandLine);
+            Assert.True(result.IsSuccess);
+            var parsedCommand = result.Value.ParsedCommand;
             Assert.NotNull(parsedCommand);
             Assert.Single(parsedCommand.Arguments);
             Assert.Equal(expected, parsedCommand.Arguments[0].Value);
@@ -67,7 +73,9 @@ namespace QuiCLI.Tests.CommandLine
             commands.AddCommandGroup("group1").AddCommand(_ => new TestCommand()).First(c => c.Name == "test2");
             var commandLine = new string[] { "group1", "test2", "--parameter", "test" };
             var parser = new CommandLineParser(commands);
-            var (parsedCommand, _) = parser.Parse(commandLine);
+            var result = parser.Parse(commandLine);
+            Assert.True(result.IsSuccess);
+            var parsedCommand = result.Value.ParsedCommand;
             Assert.NotNull(parsedCommand);
             Assert.Single(parsedCommand.Arguments);
             Assert.Equal("test", parsedCommand.Arguments[0].Value);
@@ -83,7 +91,9 @@ namespace QuiCLI.Tests.CommandLine
             var command = commands.AddCommand(_ => new TestCommand()).First(c => c.Name == "test2");
             var commandLine = new string[] { "test2", "--parameter", "test", "--help" };
             var parser = new CommandLineParser(commands);
-            var (parsedCommand, _) = parser.Parse(commandLine);
+            var result = parser.Parse(commandLine);
+            Assert.True(result.IsSuccess);
+            var parsedCommand = result.Value.ParsedCommand;
             Assert.NotNull(parsedCommand);
             Assert.Equal(2, parsedCommand.Arguments.Count);
             Assert.Contains(parsedCommand.Arguments, a => a.Name == "help");
@@ -112,6 +122,20 @@ namespace QuiCLI.Tests.CommandLine
             var optionalArgument = command.Arguments.SingleOrDefault(a => a.Name == "parameter");
             Assert.NotNull(optionalArgument);
             Assert.True(optionalArgument.IsRequired);
+        }
+
+        [Fact]
+        public void CommandLineParser_DetectMissingRequiredArguments()
+        {
+            var commands = new CommandGroup()
+            {
+                GlobalArguments = []
+            };
+            var command = commands.AddCommand(_ => new TestCommand()).First(c => c.Name == "test6");
+            var commandLine = new string[] { "test6" };
+            var parser = new CommandLineParser(commands);
+            var result = parser.Parse(commandLine);
+            Assert.True(result.IsFailure);
         }
     }
 }

--- a/QuiCLI/Command/ParsedCommand.cs
+++ b/QuiCLI/Command/ParsedCommand.cs
@@ -6,6 +6,7 @@
         public CommandDefinition Definition { get; set; }
         public CommandGroup CommandGroup { get; set; }
         public List<ArgumentValue> Arguments { get; } = [];
+
         public ParsedCommand(string name, CommandDefinition definition, CommandGroup group)
         {
             if (string.IsNullOrEmpty(name))
@@ -26,6 +27,14 @@
             }
 
             Arguments.Add(new ArgumentValue(argument, value));
+        }
+
+        public bool ValidateArguments()
+        {
+            return Definition
+                .Arguments
+                .Where(a => a.IsRequired)
+                .All(a => Arguments.Exists(arg => arg.Argument == a));
         }
     }
 }

--- a/QuiCLI/Common/Error.cs
+++ b/QuiCLI/Common/Error.cs
@@ -1,0 +1,9 @@
+﻿namespace QuiCLI.Common;
+
+public record Error(ErrorCode ErrorCode, string ErrorMessage, Exception? InnerException = null)
+{
+    public override string ToString()
+    {
+        return $"Error: {ErrorCode} - {ErrorMessage}";
+    }
+}

--- a/QuiCLI/Common/ErrorCode.cs
+++ b/QuiCLI/Common/ErrorCode.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuiCLI.Common
+{
+    public enum ErrorCode
+    {
+        NoError = 0,
+        InvalidArgument = 100,
+        MissingRequiredArgument = 101
+    }
+}

--- a/QuiCLI/Common/Result.cs
+++ b/QuiCLI/Common/Result.cs
@@ -1,0 +1,83 @@
+﻿using System.Diagnostics.Contracts;
+
+namespace QuiCLI.Common;
+
+
+public readonly struct Result<TValue> : IEquatable<Result<TValue>>, IComparable<Result<TValue>>
+{
+    public TValue Value { get; } = default!;
+    public bool IsSuccess { get; }
+    public bool IsFailure => !IsSuccess;
+    public Error? Error { get; }
+
+    public Result(TValue value)
+    {
+        Value = value;
+        IsSuccess = true;
+    }
+
+    public Result(Error error)
+    {
+        Value = default!;
+        IsSuccess = false;
+        Error = error;
+    }
+
+    public static Result<TValue> Success(TValue value) => new(value);
+
+    public static Result<TValue> Failure(Error error) => new(error);
+
+    [Pure]
+    public bool Equals(Result<TValue> other)
+    {
+        return EqualityComparer<TValue>.Default.Equals(Value, other.Value);
+    }
+
+    [Pure]
+    public int CompareTo(Result<TValue> other)
+    {
+        return Comparer<TValue>.Default.Compare(Value, other.Value);
+    }
+
+    [Pure]
+    public static implicit operator TValue(Result<TValue> result) => result.Value;
+
+    [Pure]
+    public static implicit operator Error?(Result<TValue> result) => result.Error;
+
+    [Pure]
+    public static implicit operator Result<TValue>(Error error) => Failure(error);
+
+    [Pure]
+    public static implicit operator Result<TValue>(TValue value) => Success(value);
+
+    [Pure]
+    public override int GetHashCode()
+    {
+        return Value?.GetHashCode() ?? 0;
+    }
+
+    [Pure]
+    public override bool Equals(object? obj)
+    {
+        return obj is Result<TValue> result && Equals(result);
+    }
+
+    [Pure]
+    public static bool operator ==(Result<TValue> left, Result<TValue> right)
+    {
+        return left.Equals(right);
+    }
+
+    [Pure]
+    public static bool operator !=(Result<TValue> left, Result<TValue> right)
+    {
+        return !(left == right);
+    }
+
+    [Pure]
+    public override string ToString()
+    {
+        return IsSuccess ? Value?.ToString() ?? string.Empty : Error?.ToString() ?? string.Empty;
+    }
+}

--- a/QuiCLI/QuicApp.cs
+++ b/QuiCLI/QuicApp.cs
@@ -38,21 +38,29 @@ public class QuicApp
     {
 
         var parser = new CommandLineParser(RootCommands);
-        var (command, group) = parser.Parse(Environment.GetCommandLineArgs().Skip(1).ToArray());
+        var result = parser.Parse(Environment.GetCommandLineArgs().Skip(1).ToArray());
+        if (result.IsFailure)
+        {
+            Console.WriteLine(result.Error);
+            var helpBuilder = new HelpBuilder(result.Value.CommandGroup);
+            Console.WriteLine(helpBuilder.BuildHelp());
+            Environment.Exit(1);
+        }
+        var command = result.Value.ParsedCommand;
         if (command is not null)
         {
             var context = new QuicCommandContext(command) { ServiceProvider = ServiceProvider };
-            var result = await Pipeline(context);
-            if(result == 0)
+            var executionResult = await Pipeline(context);
+            if(executionResult == 0)
             {
                 Console.WriteLine(context.CommandResult);
             }
             
-            Environment.Exit(result);
+            Environment.Exit(executionResult);
         }
         else
         {
-            var helpBuilder = new HelpBuilder(group);
+            var helpBuilder = new HelpBuilder(result.Value.CommandGroup);
             Console.WriteLine(helpBuilder.BuildHelp());
         }
     }


### PR DESCRIPTION
#### PR Classification
This pull request introduces an API change to improve error handling and validation in the command line parsing process.

#### PR Summary
The pull request modifies the `Parse` method in `CommandLineParser` to return a `Result` object and adds error handling and validation mechanisms.
- Modified `Parse` method in `CommandLineParser` to return a `Result` object instead of a tuple.
- Added a `ValidateArguments` method in `ParsedCommand` to check for missing required arguments.
- Introduced new classes `Error`, `ErrorCode`, and `Result` in `QuiCLI.Common` for better error representation.
- Updated `RunAsync` method in `QuicApp` and `ParsedCommand` constructor to handle the new `Result` return type.
- Added a new test method `CommandLineParser_DetectMissingRequiredArguments` in `ParserTests.cs` to validate the changes.
