### PR TITLE
Add configuration support 

### DIFF
--- a/QuiCLI.Tests/Middleware/MiddlewareTests.cs
+++ b/QuiCLI.Tests/Middleware/MiddlewareTests.cs
@@ -14,7 +14,7 @@ public class MiddlewareTests
 
         // Act
         var pipeline = builder.Build();
-        var context = new QuicCommandContext(null!) { ServiceProvider = null! };
+        var context = new QuicCommandContext(null!, new QuiCLI.Builder.Configuration()) { ServiceProvider = null! };
         var result = await pipeline(context);
         // Assert
         Assert.NotNull(pipeline);

--- a/QuiCLI/Builder/Configuration.cs
+++ b/QuiCLI/Builder/Configuration.cs
@@ -1,0 +1,7 @@
+﻿namespace QuiCLI.Builder
+{
+    public class Configuration
+    {
+        public Func<string>? CustomBanner { get; set; }
+    }
+}

--- a/QuiCLI/Builder/QuicAppBuilder.cs
+++ b/QuiCLI/Builder/QuicAppBuilder.cs
@@ -6,9 +6,16 @@ namespace QuiCLI.Builder;
 
 public class QuicAppBuilder
 {
+    public void Configure(Action<Configuration> configureDelegate)
+    {
+        configureDelegate(Configuration);
+    }
+
+    internal Configuration Configuration { get; } = new Configuration();
     public IServiceCollection Services { get; init; }
     public IQuicPipelineBuilder Pipeline { get; init; }
     internal List<ArgumentDefinition> GlobalArguments { get; init; } = [];
+    
     public QuicAppBuilder()
     {
         Services = new ServiceCollection();
@@ -53,6 +60,7 @@ public class QuicAppBuilder
 
         return new QuicApp
         {
+            Configuration = Configuration,
             ServiceProvider = provider,
             Pipeline = Pipeline.Build(),
             GlobalArguments = GlobalArguments,

--- a/QuiCLI/Help/HelpBuilder.cs
+++ b/QuiCLI/Help/HelpBuilder.cs
@@ -1,15 +1,21 @@
-﻿using QuiCLI.Command;
+﻿using QuiCLI.Builder;
+using QuiCLI.Command;
 using System.Text;
 
 namespace QuiCLI.Help;
 
-internal class HelpBuilder(CommandGroup rootCommandGroup)
+internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configuration)
 {
     private readonly CommandGroup rootCommandGroup = rootCommandGroup;
+    private readonly Configuration configuration = configuration;
 
     public string BuildHelp()
     {
         var sb = new StringBuilder();
+        if (configuration.CustomBanner is not null)
+        {
+            sb.AppendLine(configuration.CustomBanner());
+        }
         var groupName = rootCommandGroup.Name ?? "";
         sb.AppendLine("Usage:");
         sb.AppendLine($" {groupName} <command> [arguments]");
@@ -52,6 +58,11 @@ internal class HelpBuilder(CommandGroup rootCommandGroup)
     public string BuildHelp(CommandDefinition commandDefinition)
     {
         var sb = new StringBuilder();
+        if (configuration.CustomBanner is not null)
+        {
+            sb.AppendLine(configuration.CustomBanner());
+        }
+
         sb.AppendLine($"Usage: {commandDefinition.Name}");
         if (!string.IsNullOrWhiteSpace(commandDefinition.Help))
         {

--- a/QuiCLI/Middleware/ExceptionHandler.cs
+++ b/QuiCLI/Middleware/ExceptionHandler.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using QuiCLI.Builder;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/QuiCLI/Middleware/QuicMiddleware.cs
+++ b/QuiCLI/Middleware/QuicMiddleware.cs
@@ -1,12 +1,14 @@
-﻿using QuiCLI.Command;
+﻿using QuiCLI.Builder;
+using QuiCLI.Command;
 using System.Diagnostics.CodeAnalysis;
 
 namespace QuiCLI.Middleware;
 
 public delegate ValueTask<int> QuicMiddlewareDelegate(QuicCommandContext context);
-public class QuicCommandContext(ParsedCommand command)
+public class QuicCommandContext(ParsedCommand command, Configuration configuration)
 {
     public ParsedCommand Command { get; } = command;
+    public Configuration Configuration { get; } = configuration;
     public List<ArgumentValue> GlobalArguments { get; init; } = [];
     public required IServiceProvider ServiceProvider { get; init; }
     public object? CommandResult { get; internal set; }

--- a/QuiCLI/Middleware/StringOutputFormatter.cs
+++ b/QuiCLI/Middleware/StringOutputFormatter.cs
@@ -1,4 +1,6 @@
-﻿namespace QuiCLI.Middleware
+﻿using QuiCLI.Builder;
+
+namespace QuiCLI.Middleware
 {
     internal class StringOutputFormatter(QuicMiddlewareDelegate next) : QuicMiddleware(next)
     {

--- a/QuiCLI/QuicApp.cs
+++ b/QuiCLI/QuicApp.cs
@@ -8,6 +8,7 @@ namespace QuiCLI;
 
 public class QuicApp
 {
+    public required Configuration Configuration { get; init; }
     public required IServiceProvider ServiceProvider { get; init; }
     public required QuicMiddlewareDelegate Pipeline { get; init; }
     public required CommandGroup RootCommands { get; init; }
@@ -42,7 +43,7 @@ public class QuicApp
         if (result.IsFailure)
         {
             Console.WriteLine(result.Error);
-            var helpBuilder = new HelpBuilder(result.Value.CommandGroup ?? RootCommands);
+            var helpBuilder = new HelpBuilder(result.Value.CommandGroup ?? RootCommands, Configuration);
             Console.WriteLine(helpBuilder.BuildHelp());
             Environment.Exit(1);
         }
@@ -50,7 +51,7 @@ public class QuicApp
         if (command is not null)
         {
             var globalArguments = command.Arguments.Where(a => a.Argument.IsGlobal).ToList();
-            var context = new QuicCommandContext(command) { ServiceProvider = ServiceProvider, GlobalArguments = globalArguments };
+            var context = new QuicCommandContext(command, Configuration) { ServiceProvider = ServiceProvider, GlobalArguments = globalArguments };
             var executionResult = await Pipeline(context);
             if(executionResult == 0)
             {
@@ -61,7 +62,7 @@ public class QuicApp
         }
         else
         {
-            var helpBuilder = new HelpBuilder(result.Value.CommandGroup);
+            var helpBuilder = new HelpBuilder(result.Value.CommandGroup, Configuration);
             Console.WriteLine(helpBuilder.BuildHelp());
         }
     }

--- a/Samples/SampleApp/Program.cs
+++ b/Samples/SampleApp/Program.cs
@@ -2,6 +2,11 @@
 using SampleApp;
 
 var builder = QuicApp.CreateBuilder();
+builder.Configure(config =>
+{
+    config.CustomBanner = () => "Welcome to SampleApp!";
+});
+
 var app = builder.Build();
 
 app.AddCommand(_ => new HelloCommand());


### PR DESCRIPTION
Updated MiddlewareTests to initialize QuicCommandContext with a new Configuration object. Added Configure method and Configuration property to QuicAppBuilder. Modified QuicAppBuilder to include Configuration when building QuicApp. Updated HelpBuilder to accept Configuration for custom banner. CommandDispatcher now passes Configuration to GetCommandOutput and HelpBuilder. ExceptionHandler and StringOutputFormatter now include QuiCLI.Builder namespace. QuicCommandContext and QuicApp updated to include Configuration property. Program.cs now configures QuicAppBuilder with a custom banner. Added new Configuration class to hold settings, including CustomBanner function.