### PR TITLE
Add help argument handling and improve help text formatting

### DIFF
--- a/QuiCLI/Command/ParsedCommand.cs
+++ b/QuiCLI/Command/ParsedCommand.cs
@@ -31,7 +31,8 @@
 
         public bool ValidateArguments()
         {
-            return Definition
+            return Arguments.Any(arg => arg.Name.Equals("help", StringComparison.OrdinalIgnoreCase)) ||
+                Definition
                 .Arguments
                 .Where(a => a.IsRequired && !a.IsGlobal)
                 .All(a => Arguments.Exists(arg => arg.Argument == a));

--- a/QuiCLI/Help/HelpBuilder.cs
+++ b/QuiCLI/Help/HelpBuilder.cs
@@ -47,9 +47,11 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
         {
             sb.AppendLine();
             sb.AppendLine("Global Arguments:");
+            var maxArgLength = rootCommandGroup.GlobalArguments.Max(a => a.Name.Length);
+
             foreach (var argument in rootCommandGroup.GlobalArguments)
             {
-                sb.AppendLine($"\t--{argument.Name}\t:\t{argument.Help}");
+                sb.AppendLine($"\t--{argument.Name.PadRight(maxArgLength)}\t:\t{argument.Help}");
             }
         }
         return sb.ToString();
@@ -70,9 +72,10 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
         }
         sb.AppendLine();
         sb.AppendLine("Arguments:");
+        var maxArgLength = commandDefinition.Arguments.Max(a => a.Name.Length);
         foreach (var argument in commandDefinition.Arguments.Where(a => !a.IsGlobal))
         {
-            sb.Append($"\t--{argument.Name}");
+            sb.Append($"\t--{argument.Name.PadRight(maxArgLength)}");
             sb.Append(argument.IsFlag ? "" : $"\t:\t<{argument.ValueType.Name}>");
             if (argument.IsRequired)
             {
@@ -85,9 +88,10 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
         {
             sb.AppendLine();
             sb.AppendLine("Global Arguments:");
+
             foreach (var argument in commandDefinition.Arguments.Where(a => a.IsGlobal))
             {
-                sb.AppendLine($"\t--{argument.Name}\t:\t{argument.Help}");
+                sb.AppendLine($"\t--{argument.Name.PadRight(maxArgLength)}\t:\t{argument.Help}");
             }
         }
         return sb.ToString();


### PR DESCRIPTION
The `ValidateArguments` method in `ParsedCommand.cs` now returns `true` if any argument named "help" is present - fixes help not being printed if required arguments are missing.

In `HelpBuilder.cs`, the formatting of argument names in the help text was improved by padding the names to align the descriptions. This change was applied to both global and non-global arguments.