### PR TITLE
Add default value display in help message for arguments

### DIFF
--- a/QuiCLI/Help/HelpBuilder.cs
+++ b/QuiCLI/Help/HelpBuilder.cs
@@ -81,6 +81,12 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
             {
                 sb.Append(" [required]");
             }
+
+            if(argument.DefaultValue is not null)
+            {
+                sb.Append($" (default: {argument.DefaultValue})");
+            }
+
             sb.AppendLine();
         }
 


### PR DESCRIPTION
Enhanced the `HelpBuilder` class to include the default value of
an argument in the help message if the `DefaultValue` property
is not null. This makes the help output more informative by
indicating the default values for optional arguments.