### PR TITLE
Refactor command handling to use dependency injection

### DIFF
--- a/QuiCLI.Tests/Builder/CommandTests.cs
+++ b/QuiCLI.Tests/Builder/CommandTests.cs
@@ -27,7 +27,7 @@ namespace QuiCLI.Tests.Builder
             // Arrange
             var builder = new QuicAppBuilder();
             builder.Commands.AddCommand<TestCommand>("test")
-                .Configure(sp => new TestCommand(), x => x.Test);
+                .UseMethod(x => x.Test);
             var app = builder.Build();
 
             Assert.Single(app.RootCommands.Commands);

--- a/QuiCLI/Builder/QuicAppBuilder.cs
+++ b/QuiCLI/Builder/QuicAppBuilder.cs
@@ -20,7 +20,7 @@ public class QuicAppBuilder
     public QuicAppBuilder()
     {
         Services = new ServiceCollection();
-        Commands = CommandBuilder.CreateBuilder();
+        Commands = CommandBuilder.CreateBuilder(Services);
         Pipeline = new QuicPipelineBuilder()
             .UseMiddleware<ExceptionHandler>()
             .UseMiddleware<CommandDispatcher>()

--- a/QuiCLI/Command/CommandDefinition.cs
+++ b/QuiCLI/Command/CommandDefinition.cs
@@ -9,8 +9,6 @@ namespace QuiCLI.Command
         public string? Help { get; init; } = description;
         public required List<ParameterDefinition> Arguments { get; init; }
         internal MethodInfo? Method { get; set; }
-        internal Func<IServiceProvider, object>? ImplementationFactory { get; set; }
-
 
 
         public bool TryGetArgument(string name, out ParameterDefinition argumentDefinition)

--- a/QuiCLI/Command/CommandGroup.cs
+++ b/QuiCLI/Command/CommandGroup.cs
@@ -45,7 +45,7 @@ namespace QuiCLI.Command
                     arguments.AddRange(GlobalArguments);
                     arguments.AddRange(GetArguments(method));
 
-                    var definition = new CommandDefinition(commandAttribute.Name) { Method = method, Arguments = arguments.ToList(), Help = commandAttribute.Help, ImplementationFactory = implementationFactory };
+                    var definition = new CommandDefinition(commandAttribute.Name) { Method = method, Arguments = [.. arguments], Help = commandAttribute.Help};
                     Commands.Add(definition);
                     addedCommands.Add(definition);
                 }

--- a/QuiCLI/Command/[Fluent]/CommandBuilder.cs
+++ b/QuiCLI/Command/[Fluent]/CommandBuilder.cs
@@ -1,15 +1,21 @@
-﻿namespace QuiCLI.Command;
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics.CodeAnalysis;
+
+namespace QuiCLI.Command;
 
 public sealed class CommandBuilder : ICommandBuilder, IBuildCommands
 {
     private readonly List<IBuilderState> _commands = [];
+    private readonly IServiceCollection _services;
 
-    private CommandBuilder()
+    private CommandBuilder(IServiceCollection services)
     {
+        _services = services;
     }
 
-    IConfigureCommandInstance<TCommand> ICommandBuilder.AddCommand<TCommand>(string command) where TCommand : class
+    IConfigureCommandInstance<TCommand> ICommandBuilder.AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand>(string command) where TCommand : class
     {
+        _services.AddTransient<TCommand>();
         var state = new CommandBuilderState<TCommand>(command);
         _commands.Add(state);
         return state;
@@ -17,9 +23,9 @@ public sealed class CommandBuilder : ICommandBuilder, IBuildCommands
 
 
 
-    internal static ICommandBuilder CreateBuilder()
+    internal static ICommandBuilder CreateBuilder(IServiceCollection services)
     {
-        return new CommandBuilder();
+        return new CommandBuilder(services);
     }
 
     IEnumerable<CommandDefinition> IBuildCommands.Build()

--- a/QuiCLI/Command/[Fluent]/CommandBuilderState.cs
+++ b/QuiCLI/Command/[Fluent]/CommandBuilderState.cs
@@ -7,7 +7,6 @@ internal sealed class CommandBuilderState<TCommand> : IBuilderState, ICommandSta
 {
     private string _commandName;
     private MethodInfo? _commandMethod;
-    private Func<IServiceProvider, TCommand>? _implementationFactory;
     internal List<IBuilderState> Parameters = [];
 
     internal CommandBuilderState(string command)
@@ -16,9 +15,8 @@ internal sealed class CommandBuilderState<TCommand> : IBuilderState, ICommandSta
     }
 
 
-    ICommandState<TCommand> IConfigureCommandInstance<TCommand>.Configure(Func<IServiceProvider, TCommand> implementationFactory, Expression<Func<TCommand, Delegate>> commandDelegate)
+    ICommandState<TCommand> IConfigureCommandInstance<TCommand>.UseMethod(Expression<Func<TCommand, Delegate>> commandDelegate)
     {
-        _implementationFactory = implementationFactory;
         var unaryExpression = (UnaryExpression)commandDelegate.Body;
         var methodCallExpression = (MethodCallExpression)unaryExpression.Operand;
 
@@ -35,7 +33,7 @@ internal sealed class CommandBuilderState<TCommand> : IBuilderState, ICommandSta
 
     object IBuilderState.Build()
     {
-        if (_commandMethod is null || _implementationFactory is null)
+        if (_commandMethod is null)
         {
             throw new InvalidOperationException("Command method and implementation factory must be set");
         }
@@ -44,7 +42,6 @@ internal sealed class CommandBuilderState<TCommand> : IBuilderState, ICommandSta
         {
             Arguments = GenerateParameterDefinitions(_commandMethod).ToList(),
             Method = _commandMethod,
-            ImplementationFactory = _implementationFactory
         };
     }
     ICommandState<TCommand> ICommandState<TCommand>.WithGroup(string groupName)

--- a/QuiCLI/Command/[Fluent]/ICommandBuilder.cs
+++ b/QuiCLI/Command/[Fluent]/ICommandBuilder.cs
@@ -1,8 +1,10 @@
-﻿namespace QuiCLI.Command;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace QuiCLI.Command;
 
 public interface ICommandBuilder
 {
-    public IConfigureCommandInstance<TCommand> AddCommand<TCommand>(string command) where TCommand : class;
+    public IConfigureCommandInstance<TCommand> AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand>(string command) where TCommand : class;
 }
 
 internal interface IBuildCommands

--- a/QuiCLI/Command/[Fluent]/IConfigureCommandInstance.cs
+++ b/QuiCLI/Command/[Fluent]/IConfigureCommandInstance.cs
@@ -4,5 +4,5 @@ namespace QuiCLI.Command;
 
 public interface IConfigureCommandInstance<TCommand> where TCommand : class
 {
-    ICommandState<TCommand> Configure(Func<IServiceProvider, TCommand> commandFactory, Expression<Func<TCommand, Delegate>> commandDelegate);
+    ICommandState<TCommand> UseMethod(Expression<Func<TCommand, Delegate>> commandDelegate);
 }

--- a/QuiCLI/Middleware/CommandDispatcher.cs
+++ b/QuiCLI/Middleware/CommandDispatcher.cs
@@ -1,4 +1,5 @@
-﻿using QuiCLI.Builder;
+﻿using Microsoft.Extensions.DependencyInjection;
+using QuiCLI.Builder;
 using QuiCLI.Command;
 using QuiCLI.Help;
 using QuiCLI.Internal;
@@ -17,7 +18,8 @@ internal sealed class CommandDispatcher(QuicMiddlewareDelegate next) : QuicMiddl
 
     internal static (CommandDefinition, object) GetCommandInstance(ParsedCommand parsedCommand, IServiceProvider serviceProvider)
     {
-        return (parsedCommand.Definition, parsedCommand.Definition.ImplementationFactory!.Invoke(serviceProvider));
+        using var scope = serviceProvider.CreateScope();
+        return (parsedCommand.Definition, scope.ServiceProvider.GetRequiredService(parsedCommand.Definition.Method!.DeclaringType!));
     }
 
     internal async Task<object?> GetCommandOutput(object commandInstance, ParsedCommand parsedCommand, Configuration configuration)

--- a/Samples/SampleApp/Program.cs
+++ b/Samples/SampleApp/Program.cs
@@ -5,7 +5,7 @@ var builder = QuicApp.CreateBuilder();
 builder.Configure(config => config.CustomBanner = () => "Welcome to SampleApp!");
 
 builder.Commands.AddCommand<HelloCommand>("hello")
-    .Configure(_ => new HelloCommand(), x => x.Hello);
+    .UseMethod(x => x.Hello);
 
 var app = builder.Build();
 


### PR DESCRIPTION
Updated various classes and methods to improve command handling by leveraging dependency injection and replacing the `Configure` method with `UseMethod`. Key changes include:

- `Fluent_CreateCommand` in `CommandTests.cs` now uses `UseMethod`.
- `QuicAppBuilder` constructor initializes `Commands` with `CommandBuilder.CreateBuilder(Services)`.
- Removed `ImplementationFactory` from `CommandDefinition` and `CommandGroup`.
- `CommandBuilder` now uses `IServiceCollection` and adds transient services for commands.
- `CommandBuilderState` updated to remove `implementationFactory` and replace `Configure` with `UseMethod`.
- `ICommandBuilder` and `IConfigureCommandInstance` interfaces updated to use `DynamicallyAccessedMembers` and `UseMethod`.
- `CommandDispatcher` now uses dependency injection to create command instances.
- `Program.cs` updated to use `UseMethod` for adding commands.