### PR TITLE
Refactor command handling to use fluent API

### DIFF
--- a/QuiCLI.Tests/Builder/CommandTests.cs
+++ b/QuiCLI.Tests/Builder/CommandTests.cs
@@ -5,23 +5,6 @@ namespace QuiCLI.Tests.Builder
     public class CommandTests
     {
         [Fact]
-        public void AddCommand_ShouldAddCommand()
-        {
-            // Arrange
-            var builder = new QuicAppBuilder();
-            var app = builder.Build();
-
-
-            // Act
-            app.AddCommand(sp => new TestCommand());
-
-
-            // Assert
-            Assert.Equal(6, app.RootCommands.Commands.Count);
-            Assert.Equal("test", app.RootCommands.Commands[0].Name);
-        }
-
-        [Fact]
         public void Fluent_CreateCommand()
         {
             // Arrange
@@ -32,6 +15,20 @@ namespace QuiCLI.Tests.Builder
 
             Assert.Single(app.RootCommands.Commands);
             Assert.Equal("test", app.RootCommands.Commands[0].Name);
+        }
+
+        [Fact]
+        public void Fluent_CreateCommandSubGroup()
+        {
+            var builder = new QuicAppBuilder();
+            builder.Commands.WithGroup("cmds").Add<TestCommand>()
+                .WithCommand("test", x => x.Test);
+
+            var app = builder.Build();
+
+            Assert.Single(app.RootCommands.SubGroups);
+            Assert.Equal("cmds", app.RootCommands.SubGroups.First().Key);
+            Assert.Single(app.RootCommands.SubGroups.First().Value.Commands);
         }
     }
 }

--- a/QuiCLI/Builder/Configuration.cs
+++ b/QuiCLI/Builder/Configuration.cs
@@ -1,7 +1,10 @@
-﻿namespace QuiCLI.Builder
+﻿using QuiCLI.Command;
+
+namespace QuiCLI.Builder
 {
     public class Configuration
     {
         public Func<string>? CustomBanner { get; set; }
+        public List<ParameterDefinition> GlobalArguments { get; } = [];
     }
 }

--- a/QuiCLI/Builder/QuicAppBuilder.cs
+++ b/QuiCLI/Builder/QuicAppBuilder.cs
@@ -15,7 +15,6 @@ public class QuicAppBuilder
     public ICommandBuilder Commands { get; init; }
     public IServiceCollection Services { get; init; }
     public IQuicPipelineBuilder Pipeline { get; init; }
-    internal List<ParameterDefinition> GlobalArguments { get; init; } = [];
     
     public QuicAppBuilder()
     {
@@ -31,7 +30,7 @@ public class QuicAppBuilder
     internal void InitDefaultGlobalArguments()
     {
 
-        GlobalArguments.Add(new ParameterDefinition
+        Configuration.GlobalArguments.Add(new ParameterDefinition
         {
             Name = "help",
             InternalName = "help",
@@ -43,7 +42,7 @@ public class QuicAppBuilder
             ValueType = typeof(bool)
         });
 
-        GlobalArguments.Add(new ParameterDefinition
+        Configuration.GlobalArguments.Add(new ParameterDefinition
         {
             Name = "output",
             InternalName = "output",
@@ -60,15 +59,14 @@ public class QuicAppBuilder
     {
         var provider = Services.BuildServiceProvider();
 
-        var commands = ((IBuildCommands)Commands).Build();
+        var commandGroup = ((IBuildCommandGroup)Commands).Build();
 
         return new QuicApp
         {
             Configuration = Configuration,
             ServiceProvider = provider,
             Pipeline = Pipeline.Build(),
-            GlobalArguments = GlobalArguments,
-            RootCommands = new CommandGroup() { GlobalArguments = GlobalArguments, Commands = commands.ToList() }
+            RootCommands = commandGroup.First()
         };
     }
 }

--- a/QuiCLI/Command/CommandGroup.cs
+++ b/QuiCLI/Command/CommandGroup.cs
@@ -1,13 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-
-namespace QuiCLI.Command
+﻿namespace QuiCLI.Command
 {
     public class CommandGroup(string? name = null)
     {
         public string? Name { get; init; } = name;
 
-        public required List<ParameterDefinition> GlobalArguments { get; init; }
         public List<CommandDefinition> Commands
         {
             get; internal set;
@@ -18,72 +14,9 @@ namespace QuiCLI.Command
             get; internal set;
         } = [];
 
-        public CommandGroup AddCommandGroup(string name)
-        {
-            var group = new CommandGroup(name) { GlobalArguments = GlobalArguments };
-            SubGroups.Add(name, group);
-            return group;
-        }
-
         public CommandDefinition? GetCommand(string name)
         {
-            return Commands.FirstOrDefault(c => c.Name == name);
-        }
-
-        public IEnumerable<CommandDefinition> AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TCommand>(Func<IServiceProvider, TCommand> implementationFactory)
-    where TCommand : class
-        {
-            var addedCommands = new List<CommandDefinition>();
-            foreach (var method in typeof(TCommand)
-                .GetMethods()
-                .Where(m => m.GetCustomAttribute<CommandAttribute>() is not null))
-            {
-                var commandAttribute = method.GetCustomAttribute<CommandAttribute>();
-                if (commandAttribute is not null)
-                {
-                    var arguments = new List<ParameterDefinition>();
-                    arguments.AddRange(GlobalArguments);
-                    arguments.AddRange(GetArguments(method));
-
-                    var definition = new CommandDefinition(commandAttribute.Name) { Method = method, Arguments = [.. arguments], Help = commandAttribute.Help};
-                    Commands.Add(definition);
-                    addedCommands.Add(definition);
-                }
-            }
-            return addedCommands;
-        }
-
-        private static IEnumerable<ParameterDefinition> GetArguments(MethodInfo method)
-        {
-            var parameters = method.GetParameters();
-            var nullabilityContext = new NullabilityInfoContext();
-            foreach (var parameter in parameters)
-            {
-                var nullabilityInfo = nullabilityContext.Create(parameter);
-                yield return parameter.ParameterType switch
-                {
-                    Type t when t == typeof(bool) => new ParameterDefinition
-                    {
-                        Name = ConvertCamelCaseToParameterName(parameter.Name!),
-                        InternalName = parameter.Name!,
-                        IsFlag = true,
-                        IsRequired = nullabilityInfo.WriteState is not NullabilityState.Nullable
-                    },
-                    _ => new ParameterDefinition
-                    {
-                        Name = ConvertCamelCaseToParameterName(parameter.Name!),
-                        InternalName = parameter.Name!,
-                        IsRequired = nullabilityInfo.WriteState is not NullabilityState.Nullable && !parameter.HasDefaultValue,
-                        ValueType = parameter.ParameterType,
-                        DefaultValue = parameter.HasDefaultValue ? parameter.DefaultValue : null
-                    }
-                };
-            }
-        }
-
-        private static string ConvertCamelCaseToParameterName(string name)
-        {
-            return string.Concat(name.Select((x, i) => i > 0 && char.IsUpper(x) ? "-" + x.ToString() : x.ToString())).ToLowerInvariant();
+            return Commands.Find(c => c.Name == name);
         }
     }
 }

--- a/QuiCLI/Command/CommandLineParser.cs
+++ b/QuiCLI/Command/CommandLineParser.cs
@@ -1,11 +1,13 @@
-﻿using QuiCLI.Common;
+﻿using QuiCLI.Builder;
+using QuiCLI.Common;
 
 namespace QuiCLI.Command;
 
-internal sealed class CommandLineParser(CommandGroup rootCommandGroup)
+internal sealed class CommandLineParser(CommandGroup rootCommandGroup, Configuration configuration)
 {
     private const string LongOptionPrefix = "--";
     private const string ShortOptionPrefix = "-";
+    private readonly Configuration _configuration = configuration;
     private CommandGroup? _currentCommandGroup;
 
     public Result<(ParsedCommand? ParsedCommand, CommandGroup CommandGroup)> Parse(string[] args)
@@ -124,16 +126,14 @@ internal sealed class CommandLineParser(CommandGroup rootCommandGroup)
         {
             return true;
         }
-        if (_currentCommandGroup != null)
-        {
 
-            var globalArgument = _currentCommandGroup.GlobalArguments.Find(argument => argument.Name == argumentName);
-            if (globalArgument != null)
-            {
-                argument = globalArgument;
-                return true;
-            }
+        var globalArgument = _configuration.GlobalArguments.Find(argument => argument.Name == argumentName);
+        if (globalArgument != null)
+        {
+            argument = globalArgument;
+            return true;
         }
+
         return false;
     }
 

--- a/QuiCLI/Command/[Fluent]/CommandBuilder.cs
+++ b/QuiCLI/Command/[Fluent]/CommandBuilder.cs
@@ -3,21 +3,24 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace QuiCLI.Command;
 
-public sealed class CommandBuilder : ICommandBuilder, IBuildCommands
+public sealed class CommandBuilder : ICommandBuilder, IBuildCommandGroup
 {
-    private readonly List<IBuilderState> _commands = [];
+    private readonly List<IBuilderState> _builders = [];
     private readonly IServiceCollection _services;
+    private readonly string? GroupName;
+    private readonly List<ICommandBuilder> _subGroups = [];
 
-    private CommandBuilder(IServiceCollection services)
+    private CommandBuilder(IServiceCollection services, string? groupName = null)
     {
         _services = services;
+        GroupName = groupName;
     }
 
-    IConfigureCommandInstance<TCommand> ICommandBuilder.Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand>() where TCommand : class
+    ICommandState<TCommand> ICommandBuilder.Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand>() where TCommand : class
     {
         _services.AddTransient<TCommand>();
         var state = new CommandBuilderState<TCommand>();
-        _commands.Add(state);
+        _builders.Add(state);
         return state;
     }
 
@@ -28,8 +31,25 @@ public sealed class CommandBuilder : ICommandBuilder, IBuildCommands
         return new CommandBuilder(services);
     }
 
-    IEnumerable<CommandDefinition> IBuildCommands.Build()
+    IEnumerable<CommandGroup> IBuildCommandGroup.Build()
     {
-        return _commands.SelectMany(command => command.Build().Select(commandDefinition => (CommandDefinition)commandDefinition));
+        var group = new CommandGroup(GroupName);
+        group.Commands.AddRange(_builders.SelectMany(builder => builder.Build().Select(command => (CommandDefinition)command)));
+        var groups = _subGroups.Select(subGroup => ((IBuildCommandGroup)subGroup).Build());
+        foreach (var subGroup in groups)
+        {
+            foreach (var sub in subGroup)
+            {
+                group.SubGroups.Add(sub.Name!, sub);
+            }
+        }
+        return [group];
+    }
+
+    ICommandBuilder IConfigureCommandGroup.WithGroup(string groupName)
+    {
+        var subGroup = new CommandBuilder(_services, groupName);
+        _subGroups.Add(subGroup);
+        return subGroup;
     }
 }

--- a/QuiCLI/Command/[Fluent]/CommandBuilderState.cs
+++ b/QuiCLI/Command/[Fluent]/CommandBuilderState.cs
@@ -43,10 +43,6 @@ internal sealed class CommandBuilderState<TCommand> : IBuilderState, ICommandSta
             };
         }
     }
-    ICommandState<TCommand> ICommandState<TCommand>.WithGroup(string groupName)
-    {
-        throw new NotImplementedException();
-    }
 
     private IEnumerable<ParameterDefinition> GenerateParameterDefinitions(MethodInfo methodInfo)
     {

--- a/QuiCLI/Command/[Fluent]/ICommandBuilder.cs
+++ b/QuiCLI/Command/[Fluent]/ICommandBuilder.cs
@@ -2,12 +2,12 @@
 
 namespace QuiCLI.Command;
 
-public interface ICommandBuilder
+public interface ICommandBuilder : IConfigureCommandGroup
 {
-    public IConfigureCommandInstance<TCommand> Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand>() where TCommand : class;
+    public ICommandState<TCommand> Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TCommand>() where TCommand : class;
 }
 
-internal interface IBuildCommands
+internal interface IBuildCommandGroup
 {
-    IEnumerable<CommandDefinition> Build();
+    IEnumerable<CommandGroup> Build();
 }

--- a/QuiCLI/Command/[Fluent]/ICommandState.cs
+++ b/QuiCLI/Command/[Fluent]/ICommandState.cs
@@ -2,5 +2,4 @@
 
 public interface ICommandState<TCommand> : IConfigureCommandInstance<TCommand> where TCommand : class
 {
-    ICommandState<TCommand> WithGroup(string groupName);
 }

--- a/QuiCLI/Command/[Fluent]/IConfigureCommandGroup.cs
+++ b/QuiCLI/Command/[Fluent]/IConfigureCommandGroup.cs
@@ -1,0 +1,6 @@
+﻿namespace QuiCLI.Command;
+
+public interface IConfigureCommandGroup
+{
+    ICommandBuilder WithGroup(string groupName);
+}

--- a/QuiCLI/Help/HelpBuilder.cs
+++ b/QuiCLI/Help/HelpBuilder.cs
@@ -6,22 +6,22 @@ namespace QuiCLI.Help;
 
 internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configuration)
 {
-    private readonly CommandGroup rootCommandGroup = rootCommandGroup;
-    private readonly Configuration configuration = configuration;
+    private readonly CommandGroup _rootCommandGroup = rootCommandGroup;
+    private readonly Configuration _configuration = configuration;
 
     public string BuildHelp()
     {
         var sb = new StringBuilder();
-        if (configuration.CustomBanner is not null)
+        if (_configuration.CustomBanner is not null)
         {
-            sb.AppendLine(configuration.CustomBanner());
+            sb.AppendLine(_configuration.CustomBanner());
         }
-        var groupName = rootCommandGroup.Name ?? "";
+        var groupName = _rootCommandGroup.Name ?? "";
         sb.AppendLine("Usage:");
         sb.AppendLine($" {groupName} <command> [arguments]");
         sb.AppendLine();
         sb.AppendLine("Commands:");
-        foreach (var command in rootCommandGroup.Commands)
+        foreach (var command in _rootCommandGroup.Commands)
         {
             sb.Append($"\t{command.Name}");
             if (!string.IsNullOrWhiteSpace(command.Help))
@@ -35,21 +35,21 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
         }
 
         sb.AppendLine();
-        if (rootCommandGroup.SubGroups.Count > 0)
+        if (_rootCommandGroup.SubGroups.Count > 0)
         {
             sb.AppendLine("Nested Commands:");
-            foreach (var group in rootCommandGroup.SubGroups)
+            foreach (var group in _rootCommandGroup.SubGroups)
             {
                 sb.AppendLine($"\t{group.Key}");
             }
         }
-        if (rootCommandGroup.GlobalArguments.Count > 0)
+        if (_configuration.GlobalArguments.Count > 0)
         {
             sb.AppendLine();
             sb.AppendLine("Global Arguments:");
-            var maxArgLength = rootCommandGroup.GlobalArguments.Max(a => a.Name.Length);
+            var maxArgLength = _configuration.GlobalArguments.Max(a => a.Name.Length);
 
-            foreach (var argument in rootCommandGroup.GlobalArguments)
+            foreach (var argument in _configuration.GlobalArguments)
             {
                 sb.AppendLine($"\t--{argument.Name.PadRight(maxArgLength)}\t:\t{argument.Help}");
             }
@@ -60,9 +60,9 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
     public string BuildHelp(CommandDefinition commandDefinition)
     {
         var sb = new StringBuilder();
-        if (configuration.CustomBanner is not null)
+        if (_configuration.CustomBanner is not null)
         {
-            sb.AppendLine(configuration.CustomBanner());
+            sb.AppendLine(_configuration.CustomBanner());
         }
 
         sb.AppendLine($"Usage: {commandDefinition.Name}");

--- a/QuiCLI/QuicApp.cs
+++ b/QuiCLI/QuicApp.cs
@@ -2,7 +2,6 @@
 using QuiCLI.Command;
 using QuiCLI.Help;
 using QuiCLI.Middleware;
-using System.Diagnostics.CodeAnalysis;
 
 namespace QuiCLI;
 
@@ -19,18 +18,6 @@ public class QuicApp
     }
 
 
-    public QuicApp AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TCommand>(Func<IServiceProvider, TCommand> implementationFactory)
-        where TCommand : class
-    {
-        RootCommands.AddCommand(implementationFactory);
-        return this;
-    }
-
-    public CommandGroup AddCommandGroup(string name)
-    {
-        return RootCommands.AddCommandGroup(name);
-    }
-
     public void Run()
     {
         RunAsync().GetAwaiter().GetResult();
@@ -38,7 +25,7 @@ public class QuicApp
     public async Task RunAsync()
     {
 
-        var parser = new CommandLineParser(RootCommands);
+        var parser = new CommandLineParser(RootCommands, Configuration);
         var result = parser.Parse(Environment.GetCommandLineArgs().Skip(1).ToArray());
         if (result.IsFailure)
         {
@@ -53,11 +40,11 @@ public class QuicApp
             var globalArguments = command.Arguments.Where(a => a.Argument.IsGlobal).ToList();
             var context = new QuicCommandContext(command, Configuration) { ServiceProvider = ServiceProvider, GlobalArguments = globalArguments };
             var executionResult = await Pipeline(context);
-            if(executionResult == 0)
+            if (executionResult == 0)
             {
                 Console.WriteLine(context.CommandResult);
             }
-            
+
             Environment.Exit(executionResult);
         }
         else

--- a/Samples/SampleApp/Program.cs
+++ b/Samples/SampleApp/Program.cs
@@ -8,7 +8,8 @@ builder.Commands.Add<HelloCommand>()
     .WithCommand("hello", x => x.Hello)
     .WithCommand("bye", x => x.Bye);
 
+builder.Commands.WithGroup("greetings").Add<HelloCommand>().WithCommand("sup", x => x.Hello);
+
 var app = builder.Build();
 
-app.AddCommandGroup("sub-group").AddCommand(_ => new HelloCommand());
 app.Run();


### PR DESCRIPTION
Refactor the `QuiCLI` library to adopt a fluent and hierarchical approach for command and command group handling. Update `CommandTests.cs` and `ParserTests.cs` to reflect the new structure. Introduce `GlobalArguments` in `Configuration` for global command-line arguments. Simplify `CommandGroup` and `QuicApp` classes to rely on the builder pattern. Update `CommandLineParser`, `HelpBuilder`, and `QuicAppBuilder` to use the new configuration. Add `IConfigureCommandGroup` interface for fluent API support. Update `Program.cs` example to demonstrate the new API.