### PR TITLE
Bugfix: Add default value for flags and set as not required

### DIFF
--- a/QuiCLI.Tests/Builder/CommandTests.cs
+++ b/QuiCLI.Tests/Builder/CommandTests.cs
@@ -1,4 +1,5 @@
 ﻿using QuiCLI.Builder;
+using QuiCLI.Command;
 
 namespace QuiCLI.Tests.Builder
 {
@@ -29,6 +30,20 @@ namespace QuiCLI.Tests.Builder
             Assert.Single(app.RootCommands.SubGroups);
             Assert.Equal("cmds", app.RootCommands.SubGroups.First().Key);
             Assert.Single(app.RootCommands.SubGroups.First().Value.Commands);
+        }
+
+        [Fact]
+        public void CommandBuilder_DetectFlagParameter()
+        {
+            var builder = QuicApp.CreateBuilder();
+            builder.Commands.Add<TestCommand>()
+                .WithCommand("test5", x => x.Test5);
+            var app = builder.Build();
+            var parser = new CommandLineParser(app.RootCommands, app.Configuration);
+            var definition = app.RootCommands.Commands[0];
+
+            Assert.True(definition.Parameters[0].IsFlag);
+            Assert.False(definition.Parameters[0].IsRequired);
         }
     }
 }

--- a/QuiCLI.Tests/CommandLine/ParserTests.cs
+++ b/QuiCLI.Tests/CommandLine/ParserTests.cs
@@ -86,7 +86,7 @@ namespace QuiCLI.Tests.CommandLine
                 .WithCommand("test6", x => x.Test6);
             var app = builder.Build();
 
-            var optionalArgument = app.RootCommands.Commands[0].Arguments.SingleOrDefault(a => a.Name == "parameter2");
+            var optionalArgument = app.RootCommands.Commands[0].Parameters.SingleOrDefault(a => a.Name == "parameter2");
             Assert.NotNull(optionalArgument);
             Assert.False(optionalArgument.IsRequired);
         }
@@ -98,7 +98,7 @@ namespace QuiCLI.Tests.CommandLine
                 .WithCommand("test6", x => x.Test6);
             var app = builder.Build();
 
-            var optionalArgument = app.RootCommands.Commands[0].Arguments.SingleOrDefault(a => a.Name == "parameter");
+            var optionalArgument = app.RootCommands.Commands[0].Parameters.SingleOrDefault(a => a.Name == "parameter");
             Assert.NotNull(optionalArgument);
             Assert.True(optionalArgument.IsRequired);
         }
@@ -115,6 +115,36 @@ namespace QuiCLI.Tests.CommandLine
             var commandLine = new string[] { "test6" };
             var result = parser.Parse(commandLine);
             Assert.True(result.IsFailure);
+        }
+
+        [Fact]
+        public void CommandLineParser_ParseFlagParameterTrueWhenDefined()
+        {
+            var builder = QuicApp.CreateBuilder();
+            builder.Commands.Add<TestCommand>()
+                .WithCommand("test5", x => x.Test5);
+            var app = builder.Build();
+            var parser = new CommandLineParser(app.RootCommands, app.Configuration);
+
+            var commandLine = new string[] { "test5", "--parameter" };
+            var result = parser.Parse(commandLine);
+            var parsedCommand = result.Value.ParsedCommand;
+            Assert.True((bool)parsedCommand!.Arguments[0].Value);
+        }
+
+        [Fact]
+        public void CommandLineParser_ParseFlagParameterFalseWhenNotDefined()
+        {
+            var builder = QuicApp.CreateBuilder();
+            builder.Commands.Add<TestCommand>()
+                .WithCommand("test5", x => x.Test5);
+            var app = builder.Build();
+            var parser = new CommandLineParser(app.RootCommands, app.Configuration);
+
+            var commandLine = new string[] { "test5"};
+            var result = parser.Parse(commandLine);
+            var parsedCommand = result.Value.ParsedCommand;
+            Assert.False((bool)parsedCommand!.Arguments[0].Value);
         }
     }
 }

--- a/QuiCLI/Command/CommandDefinition.cs
+++ b/QuiCLI/Command/CommandDefinition.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace QuiCLI.Command
 {
@@ -7,15 +6,15 @@ namespace QuiCLI.Command
     {
         public string Name { get; init; } = name;
         public string? Help { get; init; } = description;
-        public required List<ParameterDefinition> Arguments { get; init; }
+        public required List<ParameterDefinition> Parameters { get; init; }
         internal MethodInfo? Method { get; set; }
 
 
-        public bool TryGetArgument(string name, out ParameterDefinition argumentDefinition)
+        public bool TryGetParameter(string name, out ParameterDefinition argumentDefinition)
         {
-            if (Arguments.Any(a => a.Name == name))
+            if (Parameters.Any(a => a.Name == name))
             {
-                argumentDefinition = Arguments.Single(a => a.Name == name);
+                argumentDefinition = Parameters.Single(a => a.Name == name);
                 return true;
             }
 

--- a/QuiCLI/Command/CommandLineParser.cs
+++ b/QuiCLI/Command/CommandLineParser.cs
@@ -62,8 +62,8 @@ internal sealed class CommandLineParser(CommandGroup rootCommandGroup, Configura
 
     private static IEnumerable<ParameterValue> FillDefaultValues(CommandDefinition commandDefinition)
     {
-        return commandDefinition.Arguments
-            .Where(a => a.DefaultValue != null && !a.IsFlag)
+        return commandDefinition.Parameters
+            .Where(a => a.DefaultValue != null)
             .Select(a => new ParameterValue(a, a.DefaultValue!));
     }
 
@@ -122,7 +122,7 @@ internal sealed class CommandLineParser(CommandGroup rootCommandGroup, Configura
     {
         var argumentName = GetArgumentName(arg);
 
-        if (commandDefinition.TryGetArgument(argumentName, out argument))
+        if (commandDefinition.TryGetParameter(argumentName, out argument))
         {
             return true;
         }

--- a/QuiCLI/Command/ParsedCommand.cs
+++ b/QuiCLI/Command/ParsedCommand.cs
@@ -33,7 +33,7 @@
         {
             return Arguments.Any(arg => arg.Name.Equals("help", StringComparison.OrdinalIgnoreCase)) ||
                 Definition
-                .Arguments
+                .Parameters
                 .Where(a => a.IsRequired && !a.IsGlobal)
                 .All(a => Arguments.Exists(arg => arg.Argument == a));
         }

--- a/QuiCLI/Command/[Fluent]/CommandBuilderState.cs
+++ b/QuiCLI/Command/[Fluent]/CommandBuilderState.cs
@@ -38,7 +38,7 @@ internal sealed class CommandBuilderState<TCommand> : IBuilderState, ICommandSta
             var commandMethod = command.Value;
             yield return new CommandDefinition(commandName)
             {
-                Arguments = GenerateParameterDefinitions(commandMethod).ToList(),
+                Parameters = GenerateParameterDefinitions(commandMethod).ToList(),
                 Method = commandMethod,
             };
         }
@@ -59,8 +59,10 @@ internal sealed class CommandBuilderState<TCommand> : IBuilderState, ICommandSta
                 {
                     Name = ConvertCamelCaseToParameterName(parameter.Name!),
                     InternalName = parameter.Name!,
+                    ValueType = typeof(bool),
                     IsFlag = true,
-                    IsRequired = nullabilityInfo.WriteState is not NullabilityState.Nullable,
+                    IsRequired = false,
+                    DefaultValue = parameter.HasDefaultValue ? parameter.DefaultValue : false,
                     Help = parameterDescriptor?.Help
                 },
                 _ => new ParameterDefinition

--- a/QuiCLI/Help/HelpBuilder.cs
+++ b/QuiCLI/Help/HelpBuilder.cs
@@ -72,8 +72,8 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
         }
         sb.AppendLine();
         sb.AppendLine("Arguments:");
-        var maxArgLength = commandDefinition.Arguments.Max(a => a.Name.Length);
-        foreach (var argument in commandDefinition.Arguments.Where(a => !a.IsGlobal))
+        var maxArgLength = commandDefinition.Parameters.Max(a => a.Name.Length);
+        foreach (var argument in commandDefinition.Parameters.Where(a => !a.IsGlobal))
         {
             sb.Append($"\t--{argument.Name.PadRight(maxArgLength)}");
             sb.Append(argument.IsFlag ? "" : $"\t:\t<{argument.ValueType.Name}>");
@@ -90,12 +90,12 @@ internal class HelpBuilder(CommandGroup rootCommandGroup, Configuration configur
             sb.AppendLine();
         }
 
-        if (commandDefinition.Arguments.Any(a => a.IsGlobal))
+        if (commandDefinition.Parameters.Any(a => a.IsGlobal))
         {
             sb.AppendLine();
             sb.AppendLine("Global Arguments:");
 
-            foreach (var argument in commandDefinition.Arguments.Where(a => a.IsGlobal))
+            foreach (var argument in commandDefinition.Parameters.Where(a => a.IsGlobal))
             {
                 sb.AppendLine($"\t--{argument.Name.PadRight(maxArgLength)}\t:\t{argument.Help}");
             }

--- a/QuiCLI/Internal/Dispatcher.cs
+++ b/QuiCLI/Internal/Dispatcher.cs
@@ -6,7 +6,7 @@ namespace QuiCLI.Internal
     {
         public static async Task<object?> InvokeAsync(object instance, ParsedCommand command)
         {
-            object?[]? parameters = GetParameters(command.Arguments, command.Definition.Arguments.Where(a => !a.IsGlobal).ToList());
+            object?[]? parameters = GetParameters(command.Arguments, command.Definition.Parameters.Where(a => !a.IsGlobal).ToList());
             var result = command.Definition.Method!.Invoke(instance, parameters);
             if (result is Task<object> taskObject)
             {


### PR DESCRIPTION
Renamed the `Arguments` property to `Parameters` across multiple files in the QuiCLI project. This includes updates to method names, variable names, and property names to reflect this change.

- Added `CommandBuilder_DetectFlagParameter` test in `CommandTests.cs`.
- Added `CommandLineParser_ParseFlagParameterTrueWhenDefined` and `CommandLineParser_ParseFlagParameterFalseWhenNotDefined` tests in `ParserTests.cs`.
- Updated `CommandDefinition` class in `CommandDefinition.cs` to use `Parameters`.
- Updated `CommandLineParser` class in `CommandLineParser.cs` to use `Parameters`.
- Updated `ParsedCommand` class in `ParsedCommand.cs` to use `Parameters`.
- Updated `CommandBuilderState` class in `CommandBuilderState.cs` to generate `Parameters` and handle flag parameters.
- Updated `HelpBuilder` class in `HelpBuilder.cs` to display `Parameters` in help text.
- Updated `Dispatcher` class in `Dispatcher.cs` to use `Parameters` when invoking commands.