### PR TITLE
Add async command support and refactor exit handling

### DIFF
--- a/QuiCLI.Tests/App/ExecutionTests.cs
+++ b/QuiCLI.Tests/App/ExecutionTests.cs
@@ -2,5 +2,17 @@
 
 public class ExecutionTests
 {
-
+    [Fact]
+    public async Task SupportsAsyncCommands()
+    {
+        var consoleWriter = new StringWriter();
+        Console.SetOut(consoleWriter);
+        var builder = QuicApp.CreateBuilder();
+        builder.Commands.Add<TestCommand>().WithCommand("async", x => x.Test7);
+        var app = builder.Build();
+       
+        var exitCode = await app.RunAsync("async");
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Task completed!", consoleWriter.ToString());
+    }
 }

--- a/QuiCLI.Tests/TestCommand.cs
+++ b/QuiCLI.Tests/TestCommand.cs
@@ -39,5 +39,11 @@ namespace QuiCLI.Tests
         {
             return $"Hello, {parameter} {parameter2 ?? ""}!";
         }
+
+        public async Task<string> Test7()
+        {
+            await Task.Delay(1000);
+            return "Task completed!";
+        }
     }
 }

--- a/QuiCLI/Middleware/StringOutputFormatter.cs
+++ b/QuiCLI/Middleware/StringOutputFormatter.cs
@@ -1,13 +1,10 @@
-﻿using QuiCLI.Builder;
+﻿namespace QuiCLI.Middleware;
 
-namespace QuiCLI.Middleware
+internal class StringOutputFormatter(QuicMiddlewareDelegate next) : QuicMiddleware(next)
 {
-    internal class StringOutputFormatter(QuicMiddlewareDelegate next) : QuicMiddleware(next)
+    public override async ValueTask<int> OnExecute(QuicCommandContext context)
     {
-        public override async ValueTask<int> OnExecute(QuicCommandContext context)
-        {
-            context.CommandResult = context.CommandResult?.ToString();
-            return await Next(context);
-        }
+        context.CommandResult = context.CommandResult?.ToString();
+        return await Next(context);
     }
 }


### PR DESCRIPTION
Added `SupportsAsyncCommands` test in `ExecutionTests.cs` to verify async command support. Introduced `Test7` async command in `TestCommand.cs`. Modified `CommandDispatcher.cs` to handle async results. Refactored `StringOutputFormatter.cs` for namespace correction and proper result conversion. Updated `QuicApp.cs` to support optional command line arguments, return exit codes, and set `Environment.ExitCode` correctly.