### PR TITLE
Fix issue with AOT and trimming when handling Task<> commands. Only support certain async return types due to limitations with trimming and generics.

### DIFF
--- a/QuiCLI.Tests/Middleware/MiddlewareTests.cs
+++ b/QuiCLI.Tests/Middleware/MiddlewareTests.cs
@@ -19,7 +19,7 @@ public class MiddlewareTests
         // Assert
         Assert.NotNull(pipeline);
         Assert.Equal(0, result);
-        Assert.Equal("Hello, world!", context.CommandResult);
+        Assert.Equal("Hello, world!", context.CommandResult!);
     }
 
     public class TestMiddleware(QuicMiddlewareDelegate next) : QuicMiddleware(next)
@@ -35,7 +35,8 @@ public class MiddlewareTests
     {
         public override async ValueTask<int> OnExecute(QuicCommandContext context)
         {
-            context.CommandResult += " world!";
+            if (context.CommandResult is not null)
+                context.CommandResult += " world!";
             return await Next(context);
         }
     }

--- a/QuiCLI/Middleware/QuicMiddleware.cs
+++ b/QuiCLI/Middleware/QuicMiddleware.cs
@@ -11,6 +11,7 @@ public class QuicCommandContext(ParsedCommand command, Configuration configurati
     public Configuration Configuration { get; } = configuration;
     public List<ParameterValue> GlobalArguments { get; init; } = [];
     public required IServiceProvider ServiceProvider { get; init; }
+
     public object? CommandResult { get; internal set; }
 }
 

--- a/QuiCLI/Middleware/StringOutputFormatter.cs
+++ b/QuiCLI/Middleware/StringOutputFormatter.cs
@@ -5,6 +5,7 @@ internal class StringOutputFormatter(QuicMiddlewareDelegate next) : QuicMiddlewa
     public override async ValueTask<int> OnExecute(QuicCommandContext context)
     {
         context.CommandResult = context.CommandResult?.ToString();
+
         return await Next(context);
     }
 }

--- a/QuiCLI/QuicApp.cs
+++ b/QuiCLI/QuicApp.cs
@@ -44,7 +44,7 @@ public class QuicApp
             var executionResult = await Pipeline(context);
             if (executionResult == 0)
             {
-                Console.WriteLine(context.CommandResult);
+                Console.WriteLine(context.CommandResult ?? string.Empty);
             }
 
             Environment.ExitCode = executionResult;

--- a/Samples/SampleApp/SampleApp.csproj
+++ b/Samples/SampleApp/SampleApp.csproj
@@ -5,6 +5,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<PublishTrimmed>true</PublishTrimmed>
 		<PublishAot>true</PublishAot>
 		<IsTrimmable>true</IsTrimmable>
 		<InvariantGlobalization>true</InvariantGlobalization>
@@ -13,6 +14,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\QuiCLI\QuiCLI.csproj" />
+		<TrimmerRootAssembly Include="QuiCLI" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Only support certain async return types due to limitations with trimming and generics.

- MiddlewareTests.cs: Added null-forgiving operator and null checks.
- CommandBuilderState.cs: Added return type validation and `IsSupportedReturnType` method.
- Dispatcher.cs: Refactored `InvokeAsync` for generic `Task<>` handling.
- CommandDispatcher.cs: Simplified `context.CommandResult` assignment.
- QuicMiddleware.cs: Added nullable `CommandResult` property.
- StringOutputFormatter.cs: Ensured `context.CommandResult` is stringified.
- QuicApp.cs: Handled null `context.CommandResult` in console output.
- SampleApp.csproj: Enabled trimming and added `QuiCLI` as root assembly.