### PR TITLE
Fix async return type check

### DIFF
--- a/QuiCLI.Tests/App/ExecutionTests.cs
+++ b/QuiCLI.Tests/App/ExecutionTests.cs
@@ -15,4 +15,18 @@ public class ExecutionTests
         Assert.Equal(0, exitCode);
         Assert.Contains("Task completed!", consoleWriter.ToString());
     }
+
+    [Fact]
+    public void PassesArgumentsCorrectlyToMethod()
+    {
+        var consoleWriter = new StringWriter();
+        Console.SetOut(consoleWriter);
+        var builder = QuicApp.CreateBuilder();
+        builder.Commands.Add<TestCommand>().WithCommand("test", x => x.Test2);
+        var app = builder.Build();
+
+        var exitCode = app.Run("test --parameter Foo");
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Foo", consoleWriter.ToString());
+    }
 }

--- a/QuiCLI/Internal/Dispatcher.cs
+++ b/QuiCLI/Internal/Dispatcher.cs
@@ -8,11 +8,10 @@ namespace QuiCLI.Internal
         {
             object?[]? parameters = GetParameters(command.Arguments, command.Definition.Parameters.Where(a => !a.IsGlobal).ToList());
             object? result;
-            if (command.Definition.Method!.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+            var returnType = command.Definition.Method!.ReturnType;
+            if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
             {
-                
-                result = await GetSupportedAsyncResult(instance, command, parameters);
-                return result;
+                return await GetSupportedAsyncResult(instance, command, parameters);
             }
 
             result = command.Definition.Method!.Invoke(instance, parameters);


### PR DESCRIPTION
Added a new test method `PassesArgumentsCorrectlyToMethod` in
`ExecutionTests.cs` to ensure that arguments are correctly passed
to a method. This test captures console output, configures a
command with a parameter, runs the command, and verifies the exit
code and parameter value in the output.

Updated the `InvokeAsync` method in `Dispatcher.cs` to correctly
check if the return type is a generic `Task<>` type before
awaiting the result, ensuring proper handling of asynchronous
methods.